### PR TITLE
Add 'Email Aliasing' category to apps.json

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -336,6 +336,19 @@
                 { "id": "calyx_os", "name": "CalyxOS" },
                 { "id": "lineage_os", "name": "LineageOS" }
             ]
+        },
+         {
+            "name": "Email Aliasing",
+            "order": 21,
+            "mainstream_apps": [
+                { "id": "no_email_aliasing", "name": "No Aliasing" }
+            ],
+            "private_alternatives": [
+                { "id": "addy_io", "name": "Addy.io" },
+                { "id": "proton_mail_simplelogin", "name": "Simple Login (by Proton)" },
+                { "id": "firefox_relay", "name": "FireFox Relay" },
+                { "id": "ddg_email_protection", "name": "Duck Duck Go: Email Protection" },
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adding a category for Email Aliasing that allows people to obsfucate their real email to improve privacy and give them more control over their email inbox.